### PR TITLE
Fix autoloader path and add a custom return function to generate a label from outside the plugin.

### DIFF
--- a/classes/Handlers/LabelRequest.php
+++ b/classes/Handlers/LabelRequest.php
@@ -26,7 +26,7 @@ class LabelRequest
         add_filter('handle_bulk_actions-edit-shop_order', [self::class, 'bulk'], 10, 3);
     }
 
-    public static function single($postID, $type, $parcelCount, $freshFreezeData = [])
+    public static function single($postID, $type, $parcelCount, $freshFreezeData = [], $redirectToDownload = true)
     {
         $currentOrder = new WC_Order($postID);
         $orderId = $currentOrder->get_id();
@@ -101,7 +101,14 @@ class LabelRequest
             self::sendTrackingMail($emailData);
         }
 
-        return Download::pdf($labelContents, $code);
+        if ($redirectToDownload) {
+            return Download::pdf($labelContents, $code);
+        }
+
+        return [
+            'labelContents' => $labelContents,
+            'code' => $code,
+        ];
     }
 
     public static function bulk($redirect_to, $action, $post_ids, $freshFreezeData = [])

--- a/dpdconnect.php
+++ b/dpdconnect.php
@@ -1,6 +1,7 @@
 <?php
 
-require_once('vendor/autoload.php');
+require_once realpath( __DIR__ . '/vendor/autoload.php' );
+
 
 /**
  * Plugin Name: DPD Connect for WooCommerce


### PR DESCRIPTION
Hi, 

With this change #56 is fixed and it’s now possible to create a label from outside the plugin (e.g. from the theme or another plugin).