### PR TITLE
2.0.6

### DIFF
--- a/classes/Handlers/Pickup.php
+++ b/classes/Handlers/Pickup.php
@@ -40,14 +40,19 @@ class Pickup
      * Generate public JWT token server-side.
      * Credentials are handled in isolated PHP context, only the token is returned.
      */
-    private static function getPublicToken(): string
+    private static function getPublicToken(): ?string
     {
-        $token = new Token(new HttpClient(Client::ENDPOINT));
-        $token->setCacheWrapper(new CacheWrapper(new Cache()));
-        return $token->getPublicJWTToken(
-            Option::connectUsername(),
-            Option::connectPassword()
-        );
+        try {
+            $token = new Token(new HttpClient(Client::ENDPOINT));
+            $token->setCacheWrapper(new CacheWrapper(new Cache()));
+            return $token->getPublicJWTToken(
+                Option::connectUsername(),
+                Option::connectPassword()
+            );
+        } catch (\Exception $e) {
+            error_log('DPD Connect: Failed to get public token - ' . $e->getMessage());
+            return null;
+        }
     }
 
     /**
@@ -189,6 +194,9 @@ class Pickup
 
         // Generate token server-side before any output
         $publicToken = self::getPublicToken();
+        if ($publicToken === null) {
+            return;
+        }
         $useGoogleMapsKey = Option::useDpdGoogleMapsKey();
         $googleMapsApiKey = Option::googleMapsApiKey();
         $ajaxUrl = admin_url('admin-ajax.php');

--- a/dpdconnect.php
+++ b/dpdconnect.php
@@ -6,7 +6,7 @@ require_once('vendor/autoload.php');
  * Plugin Name: DPD Connect for WooCommerce
  * Plugin URI: https://integrations.dpd.nl/
  * Description: Enables the posibility to integrate DPD Parcel Shop Finder service into your e-commerce store with a breeze.
- * Version: 2.0.5
+ * Version: 2.0.6
  * Author: DPD / X-Interactive.nl
  * Author URI: https://github.com/dpdconnect
  * License: GPL
@@ -38,9 +38,8 @@ defined('ABSPATH') or exit;
 // SET Root path
 define('DPDCONNECT_PLUGIN_ROOT_PATH', plugin_dir_path(__FILE__));
 
-// SET plugin version
-require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-define('DPDCONNECT_PLUGIN_VERSION', get_plugin_data(DPDCONNECT_PLUGIN_ROOT_PATH . '/dpdconnect.php')['Version']);
+// SET plugin version (avoid get_plugin_data() which triggers early textdomain loading in WP 6.7+)
+define('DPDCONNECT_PLUGIN_VERSION', '2.0.6');
 
 // Add tables for storing labels
 Activate::handle();


### PR DESCRIPTION
v2.0.6 — 30 juni 2026

Fixed
- Plugin veroorzaakt geen grote error logs meer bij een DPD API storing
- Parcelshop-bar degradeert nu graceful wanneer de DPD API onbereikbaar is (pagina blijft functioneren)
- Opgelost: WordPress 6.7+ "_load_textdomain_just_in_time" notice bij elke page load
- Opgelost: PHP 8.2+ "Creation of dynamic property" deprecation notice

Technical
- get_plugin_data() vervangen door directe versie-constante om vroege textdomain loading te voorkomen
- isset() checks toegevoegd op API response arrays in SDK (AuthenticatedHttpClient, ResourceClient, HttpClient, Token, Authentication)
- Property declaratie $httpClient toegevoegd aan Authentication klasse